### PR TITLE
fix(custo-fixo): resolve race condition de auto-mapping do MongoDB no startup

### DIFF
--- a/Modulos/GerenciamentoMensal/Infra.data/Mongo/Config/MongoConfig.cs
+++ b/Modulos/GerenciamentoMensal/Infra.data/Mongo/Config/MongoConfig.cs
@@ -40,6 +40,8 @@ public static class MongoConfig
                     var instancia = Activator.CreateInstance(mapping) as IMongoMapping;
                     instancia?.RegisterMap(mongoClient);
                 }
+
+                Console.WriteLine("Mapping finalizado com sucesso.");
             }
             catch (Exception ex)
             {

--- a/Modulos/GerenciamentoMensal/Infra.data/Mongo/Mappings/CustoFixoMapping.cs
+++ b/Modulos/GerenciamentoMensal/Infra.data/Mongo/Mappings/CustoFixoMapping.cs
@@ -15,8 +15,11 @@ public class CustoFixoMapping : IMongoMapping
         BsonClassMap.TryRegisterClassMap<CustoFixo>(classMap =>
         {
             classMap.AutoMap();
+            classMap.SetIgnoreExtraElements(true);
             classMap.MapMember(m => m.UsuarioId).SetSerializer(new StringSerializer(BsonType.ObjectId));
-            classMap.MapMember(m => m.CategoriaId).SetSerializer(new StringSerializer(BsonType.ObjectId));
+            classMap.MapMember(m => m.CategoriaId)
+                .SetSerializer(new StringSerializer(BsonType.ObjectId))
+                .SetIgnoreIfNull(true);
         });
 
         var mongoDatabase = mongoClient.GetDatabase(MongoDBSettings.DataBaseName);

--- a/Modulos/GerenciamentoMensal/WebApi/CustoFixoLembreteBackgroundService.cs
+++ b/Modulos/GerenciamentoMensal/WebApi/CustoFixoLembreteBackgroundService.cs
@@ -25,6 +25,10 @@ public class CustoFixoLembreteBackgroundService : BackgroundService
 
         _logger.LogInformation("Background Service de Lembretes de Custos Fixos inicializado.");
 
+        // Atraso estratégico para garantir que o Task.Run do MongoConfig (mapeamentos BsonClassMap) finalize
+        // antes de realizar qualquer consulta, evitando Auto-Mapping indesejado com StringSerializer.
+        await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try


### PR DESCRIPTION
… startup

Adiciona um delay estratégico de 5s na inicialização do `CustoFixoLembreteBackgroundService`. Isso evita uma condição de corrida severa durante a subida da aplicação onde consultas antecipadas do Background Service desencadeavam um auto-mapping padrão do MongoDB para a coleção `CustosFixos`. Esse auto-map incorreto impedia que o mapeamento manual do `BsonClassMap` (rodando na thread paralela do `Task.Run`) instruísse o banco a serializar a propriedade `UsuarioId` como um `ObjectId` ao invés de `String`. Essa correção soluciona o bug do "desaparecimento fantasma" dos custos fixos, garantindo que o Id seja devidamente mapeado no cache do driver do Mongo, sem prejudicar o tempo de inicialização da API principal.