### PR TITLE
fix: permitir edição completa sem trocar categoria

### DIFF
--- a/Modulos/GerenciamentoMensal/Application/Investimento/Service/InvestimentoService.cs
+++ b/Modulos/GerenciamentoMensal/Application/Investimento/Service/InvestimentoService.cs
@@ -5,6 +5,7 @@ using Application.MetaFinanceira.Interface;
 using Application.Shared.Transacao.DTOs;
 using Domain.Compartilhamento.Entity;
 using Domain.Entity;
+using Domain.Enum;
 using Domain.Login.Interfaces;
 using Domain.Relatorios.AcumuladoMensal;
 using Domain.Relatorios.Entity;
@@ -86,12 +87,15 @@ public class InvestimentoService : IInvestimentoService
         if (investimento == null)
             return Result.Failure<ResultInvestimentoDTO>(Error.NotFound("Investimento informado não existe!"));
 
-        Categoria categoria = await _categoriaRepository.GetById(updateDTO.CategoriaId);
+        if (!PertenceAoContexto(investimento))
+            return Result.Failure<ResultInvestimentoDTO>(Error.NotFound("Investimento informado não existe!"));
 
-        if (categoria == null)
-            return Result.Failure<ResultInvestimentoDTO>(Error.NotFound("Categoria informada não existe!"));
+        var categoriaResult = await ObterCategoriaParaAtualizacao(updateDTO.CategoriaId, investimento.CategoriaId, TipoCategoria.Investimento);
 
-        investimento.Atualizar(updateDTO.Descricao, updateDTO.Valor, categoria);
+        if (categoriaResult.IsFailure)
+            return Result.Failure<ResultInvestimentoDTO>(categoriaResult.Error);
+
+        investimento.Atualizar(updateDTO.Descricao, updateDTO.Valor, categoriaResult.Value);
 
         await _investimentoRepository.Update(investimento);
 
@@ -144,6 +148,9 @@ public class InvestimentoService : IInvestimentoService
         if (investimento == null)
             return Result.Failure<ResultInvestimentoDTO>(Error.NotFound("Investimento informado não existe!"));
 
+        if (!PertenceAoContexto(investimento))
+            return Result.Failure<ResultInvestimentoDTO>(Error.NotFound("Investimento informado não existe!"));
+
         investimento.AtualizarValor(updateValorTransacaoDTO.Valor);
 
         await _investimentoRepository.Update(investimento);
@@ -168,5 +175,27 @@ public class InvestimentoService : IInvestimentoService
         };
 
         return result;
+    }
+
+    private async Task<Result<Categoria>> ObterCategoriaParaAtualizacao(string categoriaIdInformada, string categoriaIdAtual, TipoCategoria tipoEsperado)
+    {
+        var categoriaId = string.IsNullOrWhiteSpace(categoriaIdInformada)
+            ? categoriaIdAtual
+            : categoriaIdInformada;
+
+        var categoria = await _categoriaRepository.GetById(categoriaId);
+
+        if (categoria == null || categoria.UsuarioId != _usuarioLogado.IdContextoDados)
+            return Result.Failure<Categoria>(Error.NotFound("Categoria informada não existe!"));
+
+        if (categoria.Tipo != tipoEsperado)
+            return Result.Failure<Categoria>(Error.Validation("Categoria informada inválida para investimento."));
+
+        return Result.Success(categoria);
+    }
+
+    private bool PertenceAoContexto(Investimento investimento)
+    {
+        return investimento.UsuarioId == _usuarioLogado.IdContextoDados;
     }
 }

--- a/Modulos/GerenciamentoMensal/Application/Rendimento/Service/RendimentoService.cs
+++ b/Modulos/GerenciamentoMensal/Application/Rendimento/Service/RendimentoService.cs
@@ -3,6 +3,7 @@ using Application.Interface;
 using Application.Shared.Transacao.DTOs;
 using Domain.Compartilhamento.Entity;
 using Domain.Entity;
+using Domain.Enum;
 using Domain.Login.Interfaces;
 using Domain.Relatorios.AcumuladoMensal;
 using Domain.Relatorios.Entity;
@@ -61,12 +62,15 @@ public class RendimentoService : IRendimentoService
         if (rendimento == null)
             return Result.Failure<ResultRendimentoDTO>(Error.NotFound("Rendimento informado não existe!"));
 
-        Categoria categoria = await _categoriaRepository.GetById(updateDTO.CategoriaId);
+        if (!PertenceAoContexto(rendimento))
+            return Result.Failure<ResultRendimentoDTO>(Error.NotFound("Rendimento informado não existe!"));
 
-        if (categoria == null)
-            return Result.Failure<ResultRendimentoDTO>(Error.NotFound("Categoria informada não existe!"));
+        var categoriaResult = await ObterCategoriaParaAtualizacao(updateDTO.CategoriaId, rendimento.CategoriaId, TipoCategoria.Rendimento);
 
-        rendimento.Atualizar(updateDTO.Descricao, updateDTO.Valor, categoria);
+        if (categoriaResult.IsFailure)
+            return Result.Failure<ResultRendimentoDTO>(categoriaResult.Error);
+
+        rendimento.Atualizar(updateDTO.Descricao, updateDTO.Valor, categoriaResult.Value);
 
         await _rendimentoRepository.Update(rendimento);
 
@@ -123,6 +127,9 @@ public class RendimentoService : IRendimentoService
         if (rendimento == null)
             return Result.Failure<ResultRendimentoDTO>(Error.NotFound("Rendimento informado não existe!"));
 
+        if (!PertenceAoContexto(rendimento))
+            return Result.Failure<ResultRendimentoDTO>(Error.NotFound("Rendimento informado não existe!"));
+
         rendimento.AtualizarValor(updateValorTransacaoDTO.Valor);
 
         await _rendimentoRepository.Update(rendimento);
@@ -149,6 +156,28 @@ public class RendimentoService : IRendimentoService
         };
 
         return result;
+    }
+
+    private async Task<Result<Categoria>> ObterCategoriaParaAtualizacao(string categoriaIdInformada, string categoriaIdAtual, TipoCategoria tipoEsperado)
+    {
+        var categoriaId = string.IsNullOrWhiteSpace(categoriaIdInformada)
+            ? categoriaIdAtual
+            : categoriaIdInformada;
+
+        var categoria = await _categoriaRepository.GetById(categoriaId);
+
+        if (categoria == null || categoria.UsuarioId != _usuarioLogado.IdContextoDados)
+            return Result.Failure<Categoria>(Error.NotFound("Categoria informada não existe!"));
+
+        if (categoria.Tipo != tipoEsperado)
+            return Result.Failure<Categoria>(Error.Validation("Categoria informada inválida para rendimento."));
+
+        return Result.Success(categoria);
+    }
+
+    private bool PertenceAoContexto(Rendimento rendimento)
+    {
+        return rendimento.UsuarioId == _usuarioLogado.IdContextoDados;
     }
     #endregion
 }

--- a/Modulos/GerenciamentoMensal/Application/Shared/Transacao/DTOs/UpdateTransacaoDTO.cs
+++ b/Modulos/GerenciamentoMensal/Application/Shared/Transacao/DTOs/UpdateTransacaoDTO.cs
@@ -5,5 +5,5 @@ public class UpdateTransacaoDTO
     public string Id { get; set; }
     public string Descricao { get; set; }
     public decimal Valor { get; set; }
-    public string CategoriaId { get; set; }
+    public string CategoriaId { get; set; } = string.Empty;
 }


### PR DESCRIPTION
Este PR corrige o fluxo completo de edição de rendimentos e investimentos, permitindo atualizar descrição e valor sem exigir o envio de CategoriaId.

Alterações

CategoriaId passa a ser opcional no DTO de atualização de transações.
Quando CategoriaId não é enviado, a categoria atual da transação é mantida.
Quando CategoriaId é enviado, o backend valida:
se a categoria existe;
se pertence ao contexto de dados atual;
se o tipo da categoria é compatível com rendimento ou investimento.
Adicionada validação de contexto também no fluxo de atualização apenas de valor.