### PR TITLE
fix(mongo): Inicializa mapeamentos durante o startup

### DIFF
--- a/Modulos/GerenciamentoMensal/Infra.data/Mongo/Config/MongoConfig.cs
+++ b/Modulos/GerenciamentoMensal/Infra.data/Mongo/Config/MongoConfig.cs
@@ -52,6 +52,7 @@ public static class MongoConfig
         catch (Exception ex)
         {
             logger.LogError(ex, "Ocorreu um erro ao registrar as classes, indexes e configuracoes do MongoDB.");
+            throw;
         }
 
     }
@@ -67,5 +68,10 @@ public static class MongoConfig
 
             return mongoClient;
         });
+    }
+
+    public static void InicializarMongoDB(this IServiceProvider serviceProvider)
+    {
+        serviceProvider.GetRequiredService<IMongoClient>();
     }
 }

--- a/Modulos/GerenciamentoMensal/Infra.data/Mongo/Mappings/Transacao/TransacaoMapping.cs
+++ b/Modulos/GerenciamentoMensal/Infra.data/Mongo/Mappings/Transacao/TransacaoMapping.cs
@@ -48,6 +48,7 @@ internal class TransacaoMapping : IMongoMappingClassBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Erro ao criar indice da collection {CollectionName}.", collection.CollectionNamespace.CollectionName);
+            throw;
         }
     }
 }

--- a/Modulos/GerenciamentoMensal/WebApi/CustoFixoLembreteBackgroundService.cs
+++ b/Modulos/GerenciamentoMensal/WebApi/CustoFixoLembreteBackgroundService.cs
@@ -25,10 +25,6 @@ public class CustoFixoLembreteBackgroundService : BackgroundService
 
         _logger.LogInformation("Background Service de Lembretes de Custos Fixos inicializado.");
 
-        // Atraso estratégico para garantir que o Task.Run do MongoConfig (mapeamentos BsonClassMap) finalize
-        // antes de realizar qualquer consulta, evitando Auto-Mapping indesejado com StringSerializer.
-        await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
-
         while (!stoppingToken.IsCancellationRequested)
         {
             try

--- a/Modulos/GerenciamentoMensal/WebApi/Program.cs
+++ b/Modulos/GerenciamentoMensal/WebApi/Program.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using Domain.Login.Interfaces;
 using Infra;
 using Infra.Autenticacao;
+using Infra.Data.Mongo.Config;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
@@ -94,6 +95,7 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
+app.Services.InicializarMongoDB();
 
 app.UseCors();
 app.UseAuthentication();


### PR DESCRIPTION
Resolva o cliente Mongo antes de configurar o pipeline para garantir que os mapeamentos e índices estejam prontos antes de requisições e serviços em background.

Interrompa a subida quando a configuração do Mongo falhar e remova o atraso artificial do serviço de lembretes.