### PR TITLE
fix(despesas): Agrupe despesas em lote ao editar

### DIFF
--- a/Modulos/GerenciamentoMensal/Application/Despesa/DTOs/AtualizarLoteDespesaDTO.cs
+++ b/Modulos/GerenciamentoMensal/Application/Despesa/DTOs/AtualizarLoteDespesaDTO.cs
@@ -7,6 +7,7 @@ namespace Application.DTOs
         public decimal NovoValor { get; set; }
         public string NovaDescricao { get; set; }
         public string NovaCategoriaId { get; set; }
+        public string IdDespesaAgrupadora { get; set; }
         public ModificadorLote Modificador { get; set; }
     }
 }

--- a/Modulos/GerenciamentoMensal/Application/Despesa/Services/DespesaService.cs
+++ b/Modulos/GerenciamentoMensal/Application/Despesa/Services/DespesaService.cs
@@ -108,12 +108,8 @@ public class DespesaService : IDespesaService
 
             var valorAgrupamento = await _repository.GetValorTotalDespesasDaAgrupadora(despesa.IdDespesaAgrupadora);
 
-            if (despesaAgrupadora.Valor < valorAgrupamento)
-            {
-                despesaAgrupadora.Valor = valorAgrupamento;
-
-                await _repository.Update(despesaAgrupadora);
-            }
+            despesaAgrupadora.Valor = valorAgrupamento;
+            await _repository.Update(despesaAgrupadora);
 
             despesa.Agrupadora = despesaAgrupadora;
         }
@@ -423,8 +419,30 @@ public class DespesaService : IDespesaService
                 despesasParaAtualizar = loteCompleto.Where(d => d.Ano > despesaAlvo.Ano || (d.Ano == despesaAlvo.Ano && d.Mes >= despesaAlvo.Mes));
         }
 
+        despesasParaAtualizar = despesasParaAtualizar.ToList();
+
+        var idsAgrupadorasAfetadas = new HashSet<string>();
+        Despesa agrupadoraReferencia = null;
+
+        if (dto.IdDespesaAgrupadora != null && dto.IdDespesaAgrupadora.PossuiValor())
+        {
+            agrupadoraReferencia = await _repository.GetById(dto.IdDespesaAgrupadora);
+
+            if (agrupadoraReferencia == null)
+                return Result.Failure(Error.NotFound("Despesa agrupadora não encontrada."));
+        }
+
         foreach (var despesa in despesasParaAtualizar)
         {
+            var resultAgrupamento = await AtualizarAgrupamentoDespesaEmLote(
+                despesa,
+                dto.IdDespesaAgrupadora,
+                agrupadoraReferencia,
+                idsAgrupadorasAfetadas);
+
+            if (resultAgrupamento.IsFailure)
+                return Result.Failure(resultAgrupamento.Error);
+
             if (despesa.IsParcelado)
             {
                 despesa.Descricao = $"{dto.NovaDescricao} ({despesa.ParcelaAtual}/{despesa.TotalParcelas})";
@@ -441,29 +459,89 @@ public class DespesaService : IDespesaService
 
         await _repository.UpdateManyAsync(despesasParaAtualizar);
 
-        // Recalcular o valor de cada agrupadora afetada
-        var agrupadorasAfetadas = new HashSet<string>();
         foreach (var despesa in despesasParaAtualizar)
         {
             if (despesa.EstaAgrupada())
-                agrupadorasAfetadas.Add(despesa.IdDespesaAgrupadora);
+                idsAgrupadorasAfetadas.Add(despesa.IdDespesaAgrupadora);
         }
 
-        foreach (var idAgrupadora in agrupadorasAfetadas)
+        await RecalcularAgrupadoras(idsAgrupadorasAfetadas);
+
+        return Result.Success();
+    }
+
+    private async Task<Result> AtualizarAgrupamentoDespesaEmLote(
+        Despesa despesa,
+        string idDespesaAgrupadora,
+        Despesa agrupadoraReferencia,
+        HashSet<string> idsAgrupadorasAfetadas)
+    {
+        if (idDespesaAgrupadora == null)
+            return Result.Success();
+
+        if (despesa.EstaAgrupada())
+            idsAgrupadorasAfetadas.Add(despesa.IdDespesaAgrupadora);
+
+        if (idDespesaAgrupadora.PossuiValor() == false)
+        {
+            await RemoverAgrupamentoDespesaEmLote(despesa, idsAgrupadorasAfetadas);
+            return Result.Success();
+        }
+
+        if (agrupadoraReferencia == null)
+            return Result.Failure(Error.NotFound("Despesa agrupadora não encontrada."));
+
+        var agrupadoraDoMes = await ObterOuClonarAgrupadora(agrupadoraReferencia, despesa.Ano, despesa.Mes);
+
+        if (despesa.IdDespesaAgrupadora == agrupadoraDoMes.Id)
+        {
+            despesa.Agrupadora = agrupadoraDoMes;
+            idsAgrupadorasAfetadas.Add(agrupadoraDoMes.Id);
+            return Result.Success();
+        }
+
+        await RemoverAgrupamentoDespesaEmLote(despesa, idsAgrupadorasAfetadas);
+
+        despesa.AdicionarDespesaAgrupadora(agrupadoraDoMes);
+        despesa.Agrupadora = agrupadoraDoMes;
+        agrupadoraDoMes.MarcarDespesaComoAgrupadora();
+        idsAgrupadorasAfetadas.Add(agrupadoraDoMes.Id);
+        await _repository.Update(agrupadoraDoMes);
+
+        return Result.Success();
+    }
+
+    private async Task RemoverAgrupamentoDespesaEmLote(Despesa despesa, HashSet<string> idsAgrupadorasAfetadas)
+    {
+        if (despesa.EstaAgrupada() == false)
+            return;
+
+        var idAgrupadoraAtual = despesa.IdDespesaAgrupadora;
+        var agrupadoraAtual = await _repository.GetById(idAgrupadoraAtual);
+
+        if (agrupadoraAtual != null)
+        {
+            agrupadoraAtual.DiminuirAgrupamento(despesa);
+            idsAgrupadorasAfetadas.Add(idAgrupadoraAtual);
+            await _repository.Update(agrupadoraAtual);
+        }
+
+        despesa.RemoverDespesaAgrupadora();
+        despesa.Agrupadora = null;
+    }
+
+    private async Task RecalcularAgrupadoras(IEnumerable<string> idsAgrupadoras)
+    {
+        foreach (var idAgrupadora in idsAgrupadoras.Where(x => x.PossuiValor()).Distinct())
         {
             var agrupadora = await _repository.GetById(idAgrupadora);
             if (agrupadora != null)
             {
                 var valorTotal = await _repository.GetValorTotalDespesasDaAgrupadora(idAgrupadora);
-                if (agrupadora.Valor < valorTotal)
-                {
-                    agrupadora.AtualizarValor(valorTotal);
-                    await _repository.Update(agrupadora);
-                }
+                agrupadora.AtualizarValor(valorTotal);
+                await _repository.Update(agrupadora);
             }
         }
-
-        return Result.Success();
     }
 
     public async Task<Result> ExcluirDespesaEmLoteAsync(string id, ModificadorLote modificador)

--- a/Modulos/GerenciamentoMensal/Tests/DespesaLoteAgrupamentoTests.cs
+++ b/Modulos/GerenciamentoMensal/Tests/DespesaLoteAgrupamentoTests.cs
@@ -1,0 +1,333 @@
+using System.Linq.Expressions;
+using Application.DTOs;
+using Application.Services;
+using Domain;
+using Domain.Compartilhamento.Entity;
+using Domain.Entity;
+using Domain.Enum;
+using Domain.Enums;
+using Domain.Login.Interfaces;
+using Domain.Relatorios.AcumuladoMensal;
+using Domain.Relatorios.Entity;
+using Domain.Repository;
+using Xunit;
+
+namespace Tests;
+
+public class DespesaLoteAgrupamentoTests
+{
+    [Fact]
+    public async Task AtualizarDespesaEmLote_ApenasEsta_AgrupaSomenteDespesaAlvo()
+    {
+        var contexto = CriarContextoParcelado();
+        var agrupadora = contexto.CriarAgrupadora("cartao-1", 2026, 1);
+        var service = contexto.CriarService();
+
+        var resultado = await service.AtualizarDespesaEmLoteAsync("parcela-1", new AtualizarLoteDespesaDTO
+        {
+            NovoValor = 90,
+            NovaDescricao = "Compra",
+            NovaCategoriaId = contexto.CategoriaDespesa.Id,
+            IdDespesaAgrupadora = agrupadora.Id,
+            Modificador = ModificadorLote.ApenasEsta
+        });
+
+        Assert.True(resultado.IsSucess);
+        Assert.Equal(agrupadora.Id, contexto.Repository.Get("parcela-1").IdDespesaAgrupadora);
+        Assert.Null(contexto.Repository.Get("parcela-2").IdDespesaAgrupadora);
+        Assert.Null(contexto.Repository.Get("parcela-3").IdDespesaAgrupadora);
+        Assert.Equal(90, contexto.Repository.Get(agrupadora.Id).Valor);
+    }
+
+    [Fact]
+    public async Task AtualizarDespesaEmLote_EstaEProximas_AgrupaAlvoEParcelasFuturas()
+    {
+        var contexto = CriarContextoParcelado();
+        var agrupadora = contexto.CriarAgrupadora("cartao-1", 2026, 1);
+        var service = contexto.CriarService();
+
+        var resultado = await service.AtualizarDespesaEmLoteAsync("parcela-2", new AtualizarLoteDespesaDTO
+        {
+            NovoValor = 70,
+            NovaDescricao = "Compra",
+            NovaCategoriaId = contexto.CategoriaDespesa.Id,
+            IdDespesaAgrupadora = agrupadora.Id,
+            Modificador = ModificadorLote.EstaEProximas
+        });
+
+        Assert.True(resultado.IsSucess);
+        Assert.Null(contexto.Repository.Get("parcela-1").IdDespesaAgrupadora);
+        Assert.NotNull(contexto.Repository.Get("parcela-2").IdDespesaAgrupadora);
+        Assert.NotNull(contexto.Repository.Get("parcela-3").IdDespesaAgrupadora);
+        Assert.Equal(70, contexto.Repository.Get("parcela-2").Agrupadora.Valor);
+        Assert.Equal(70, contexto.Repository.Get("parcela-3").Agrupadora.Valor);
+    }
+
+    [Fact]
+    public async Task AtualizarDespesaEmLote_TodasDoLote_AgrupaTodasAsParcelas()
+    {
+        var contexto = CriarContextoParcelado();
+        var agrupadora = contexto.CriarAgrupadora("cartao-1", 2026, 1);
+        var service = contexto.CriarService();
+
+        var resultado = await service.AtualizarDespesaEmLoteAsync("parcela-2", new AtualizarLoteDespesaDTO
+        {
+            NovoValor = 50,
+            NovaDescricao = "Compra",
+            NovaCategoriaId = contexto.CategoriaDespesa.Id,
+            IdDespesaAgrupadora = agrupadora.Id,
+            Modificador = ModificadorLote.TodasDoLote
+        });
+
+        Assert.True(resultado.IsSucess);
+        Assert.All(contexto.Parcelas, despesa => Assert.NotNull(despesa.IdDespesaAgrupadora));
+        Assert.All(contexto.Parcelas, despesa => Assert.Equal(50, despesa.Agrupadora.Valor));
+    }
+
+    [Fact]
+    public async Task AtualizarDespesaEmLote_TrocaAgrupadora_RecalculaAgrupadorasAntigaENova()
+    {
+        var contexto = CriarContextoParcelado();
+        var agrupadoraAntiga = contexto.CriarAgrupadora("cartao-antigo", 2026, 1);
+        var agrupadoraNova = contexto.CriarAgrupadora("cartao-novo", 2026, 1);
+        contexto.Vincular(contexto.Repository.Get("parcela-1"), agrupadoraAntiga);
+        contexto.Vincular(contexto.Repository.Get("parcela-2"), agrupadoraAntiga);
+        contexto.Vincular(contexto.Repository.Get("parcela-3"), agrupadoraAntiga);
+        var service = contexto.CriarService();
+
+        var resultado = await service.AtualizarDespesaEmLoteAsync("parcela-1", new AtualizarLoteDespesaDTO
+        {
+            NovoValor = 40,
+            NovaDescricao = "Compra",
+            NovaCategoriaId = contexto.CategoriaDespesa.Id,
+            IdDespesaAgrupadora = agrupadoraNova.Id,
+            Modificador = ModificadorLote.TodasDoLote
+        });
+
+        Assert.True(resultado.IsSucess);
+        Assert.All(contexto.Parcelas, despesa => Assert.NotEqual(agrupadoraAntiga.Id, despesa.IdDespesaAgrupadora));
+        Assert.Equal(agrupadoraNova.Id, contexto.Repository.Get("parcela-1").IdDespesaAgrupadora);
+        Assert.Equal(0, contexto.Repository.Get(agrupadoraAntiga.Id).Valor);
+        Assert.All(contexto.Parcelas, despesa => Assert.Equal(40, despesa.Agrupadora.Valor));
+    }
+
+    [Fact]
+    public async Task AtualizarDespesaEmLote_RemoveAgrupamento_RecalculaAgrupadora()
+    {
+        var contexto = CriarContextoParcelado();
+        var agrupadora = contexto.CriarAgrupadora("cartao-1", 2026, 1);
+        contexto.Vincular(contexto.Repository.Get("parcela-1"), agrupadora);
+        contexto.Vincular(contexto.Repository.Get("parcela-2"), agrupadora);
+        contexto.Vincular(contexto.Repository.Get("parcela-3"), agrupadora);
+        var service = contexto.CriarService();
+
+        var resultado = await service.AtualizarDespesaEmLoteAsync("parcela-1", new AtualizarLoteDespesaDTO
+        {
+            NovoValor = 30,
+            NovaDescricao = "Compra",
+            NovaCategoriaId = contexto.CategoriaDespesa.Id,
+            IdDespesaAgrupadora = string.Empty,
+            Modificador = ModificadorLote.TodasDoLote
+        });
+
+        Assert.True(resultado.IsSucess);
+        Assert.All(contexto.Parcelas, despesa => Assert.Null(despesa.IdDespesaAgrupadora));
+        Assert.Equal(0, contexto.Repository.Get(agrupadora.Id).Valor);
+    }
+
+    [Fact]
+    public async Task AtualizarDespesaEmLote_ValorAumentaOuDiminui_RecalculaAgrupadora()
+    {
+        var contexto = CriarContextoParcelado();
+        var agrupadora = contexto.CriarAgrupadora("cartao-1", 2026, 1);
+        contexto.Vincular(contexto.Repository.Get("parcela-1"), agrupadora);
+        var service = contexto.CriarService();
+
+        var resultadoAumentar = await service.AtualizarDespesaEmLoteAsync("parcela-1", new AtualizarLoteDespesaDTO
+        {
+            NovoValor = 120,
+            NovaDescricao = "Compra",
+            NovaCategoriaId = contexto.CategoriaDespesa.Id,
+            IdDespesaAgrupadora = agrupadora.Id,
+            Modificador = ModificadorLote.ApenasEsta
+        });
+
+        var resultadoDiminuir = await service.AtualizarDespesaEmLoteAsync("parcela-1", new AtualizarLoteDespesaDTO
+        {
+            NovoValor = 25,
+            NovaDescricao = "Compra",
+            NovaCategoriaId = contexto.CategoriaDespesa.Id,
+            IdDespesaAgrupadora = agrupadora.Id,
+            Modificador = ModificadorLote.ApenasEsta
+        });
+
+        Assert.True(resultadoAumentar.IsSucess);
+        Assert.True(resultadoDiminuir.IsSucess);
+        Assert.Equal(25, contexto.Repository.Get(agrupadora.Id).Valor);
+    }
+
+    private static TestContext CriarContextoParcelado()
+    {
+        var usuario = new Usuario("Usuario Teste", "usuario@teste.com") { Id = "usuario-1" };
+        var categoria = new Categoria("Compras", TipoCategoria.Despesa, usuario.Id) { Id = "categoria-despesa" };
+        var repository = new DespesaRepositoryFake();
+
+        for (var i = 1; i <= 3; i++)
+        {
+            repository.Despesas.Add(new Despesa(2026, i, "Compra", 100, categoria, usuario)
+            {
+                Id = $"parcela-{i}",
+                DespesaOrigemId = "lote-1",
+                IsParcelado = true,
+                ParcelaAtual = i,
+                TotalParcelas = 3
+            });
+        }
+
+        return new TestContext(
+            usuario,
+            categoria,
+            repository,
+            new CategoriaRepositoryFake(categoria),
+            new AcumuladoMensalReportRepositoryFake());
+    }
+
+    private sealed class TestContext(
+        Usuario usuario,
+        Categoria categoriaDespesa,
+        DespesaRepositoryFake repository,
+        CategoriaRepositoryFake categoriaRepository,
+        AcumuladoMensalReportRepositoryFake reportRepository)
+    {
+        public Categoria CategoriaDespesa => categoriaDespesa;
+        public DespesaRepositoryFake Repository => repository;
+        public List<Despesa> Parcelas => repository.Despesas.Where(x => x.DespesaOrigemId == "lote-1").OrderBy(x => x.ParcelaAtual).ToList();
+
+        public DespesaService CriarService() =>
+            new(repository, categoriaRepository, reportRepository, new UsuarioLogadoFake(usuario));
+
+        public Despesa CriarAgrupadora(string id, int ano, int mes)
+        {
+            var agrupadora = new Despesa(ano, mes, "Cartao", 0, categoriaDespesa, usuario)
+            {
+                Id = id
+            };
+            repository.Despesas.Add(agrupadora);
+            return agrupadora;
+        }
+
+        public void Vincular(Despesa despesa, Despesa agrupadora)
+        {
+            despesa.AdicionarDespesaAgrupadora(agrupadora);
+            agrupadora.MarcarDespesaComoAgrupadora();
+            agrupadora.AtualizarValor(agrupadora.Valor + despesa.Valor);
+        }
+    }
+
+    private sealed class UsuarioLogadoFake(Usuario usuario) : IUsuarioLogado
+    {
+        public string Id => usuario.Id;
+        public Usuario Usuario => usuario;
+        public string IdContextoDados => usuario.Id;
+        public Usuario UsuarioContextoDados => usuario;
+        public bool EmModoCompartilhado => false;
+        public NivelPermissao? PermissaoAtual => null;
+    }
+
+    private sealed class DespesaRepositoryFake : IDespesaRepository
+    {
+        public List<Despesa> Despesas { get; } = [];
+
+        public Despesa Get(string id) => Despesas.Single(x => x.Id == id);
+
+        public Task<Despesa> Add(Despesa entity)
+        {
+            if (string.IsNullOrEmpty(entity.Id))
+                entity.Id = $"despesa-{Despesas.Count + 1}";
+
+            Despesas.Add(entity);
+            return Task.FromResult(entity);
+        }
+
+        public Task<List<Despesa>> Add(List<Despesa> entity)
+        {
+            Despesas.AddRange(entity);
+            return Task.FromResult(entity);
+        }
+
+        public Task<Despesa> Update(Despesa entity) => Task.FromResult(entity);
+
+        public Task Delete(Despesa entity)
+        {
+            Despesas.Remove(entity);
+            return Task.CompletedTask;
+        }
+
+        public Task<Despesa> GetById(string id)
+        {
+            var despesa = Despesas.FirstOrDefault(x => x.Id == id);
+            if (despesa?.EstaAgrupada() == true)
+                despesa.Agrupadora = Despesas.FirstOrDefault(x => x.Id == despesa.IdDespesaAgrupadora);
+
+            return Task.FromResult(despesa!);
+        }
+
+        public Task<List<Despesa>> GetByIds(List<string> ids) =>
+            Task.FromResult(Despesas.Where(x => ids.Contains(x.Id)).ToList());
+
+        public Task<IEnumerable<Despesa>> GetWhere(Expression<Func<Despesa, bool>> filtro) =>
+            Task.FromResult(Despesas.Where(filtro.Compile()).AsEnumerable());
+
+        public Task<IEnumerable<Despesa>> ObterPeloMes(int mes, int ano, string usuarioId) =>
+            Task.FromResult(Despesas.Where(x => x.Mes == mes && x.Ano == ano && x.UsuarioId == usuarioId).AsEnumerable());
+
+        public Task<decimal> GetValorTotalDespesasDaAgrupadora(string idDespesaAgrupadora) =>
+            Task.FromResult(Despesas.Where(x => x.IdDespesaAgrupadora == idDespesaAgrupadora).Sum(x => x.Valor));
+
+        public Task<IEnumerable<Despesa>> GetPeloMes(int mes, int ano, string usuarioId, string descricao) =>
+            Task.FromResult(Despesas.Where(x => x.Mes == mes && x.Ano == ano && x.UsuarioId == usuarioId).AsEnumerable());
+
+        public Task<IEnumerable<Despesa>> GetDespesasDaAgrupadora(string idDespesaAgrupadora) =>
+            Task.FromResult(Despesas.Where(x => x.IdDespesaAgrupadora == idDespesaAgrupadora).AsEnumerable());
+
+        public Task<IEnumerable<Despesa>> GetDespesasDoLoteAsync(string despesaOrigemId) =>
+            Task.FromResult(Despesas.Where(x => x.DespesaOrigemId == despesaOrigemId).AsEnumerable());
+
+        public Task InsertManyAsync(IEnumerable<Despesa> despesas)
+        {
+            Despesas.AddRange(despesas);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateManyAsync(IEnumerable<Despesa> despesas) => Task.CompletedTask;
+
+        public Task DeleteManyAsync(IEnumerable<Despesa> despesas)
+        {
+            foreach (var despesa in despesas.ToList())
+                Despesas.Remove(despesa);
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CategoriaRepositoryFake(Categoria categoria) : ICategoriaRepository
+    {
+        public Task<Categoria> GetById(string id) => Task.FromResult(id == categoria.Id ? categoria : null!);
+        public IQueryable<Categoria> GetCategorias() => new List<Categoria> { categoria }.AsQueryable();
+        public bool CategoriaJaExiste(string nome, string idUsuario, TipoCategoria tipo) => false;
+        public Task<List<Categoria>> GetCategorias(TipoCategoria tipoCategoria, string nome, string idUsuario) => Task.FromResult(new List<Categoria> { categoria });
+        public Task<bool> CategoriaPossuiVinculo(Categoria Categoria) => Task.FromResult(false);
+        public Task<Categoria> Add(Categoria entity) => Task.FromResult(entity);
+        public Task<List<Categoria>> Add(List<Categoria> entity) => Task.FromResult(entity);
+        public Task<Categoria> Update(Categoria entity) => Task.FromResult(entity);
+        public Task Delete(Categoria entity) => Task.CompletedTask;
+        public Task<List<Categoria>> GetByIds(List<string> ids) => Task.FromResult(new List<Categoria> { categoria });
+        public Task<IEnumerable<Categoria>> GetWhere(Expression<Func<Categoria, bool>> filtro) => Task.FromResult(new List<Categoria> { categoria }.Where(filtro.Compile()).AsEnumerable());
+    }
+
+    private sealed class AcumuladoMensalReportRepositoryFake : IAcumuladoMensalReportRepository
+    {
+        public Task<AcumuladoMensalReport> Obter(int mes, int ano, string idUsuario) =>
+            Task.FromResult(new AcumuladoMensalReport(ano, mes, 0, 0, 0));
+    }
+}


### PR DESCRIPTION
Permite aplicar o agrupamento escolhido ao editar despesas parceladas ou recorrentes em lote. Recalcula agrupadoras afetadas mesmo quando valores diminuem ou vínculos são removidos.